### PR TITLE
fix: force renovate semantic commits

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
     ":automergeTesters",
     ":automergeLinters",
     ":automergeTypes",
-    ":automergePatch"
+    ":automergePatch",
+    ":semanticCommits"
   ]
 }


### PR DESCRIPTION
This PR updates renovate config to force semantic commits.
I noticed that when some merges were squashed renovate stopped detecting that we're using conventional commit format.