### PR TITLE
chore: renovate group minor + weekly schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,8 @@
   "extends": [
     "config:base",
     ":rebaseStalePrs",
+    "group:allNonMajor",
+    "schedule:earlyMondays",
     ":automergeMinor",
     ":automergeTesters",
     ":automergeLinters",


### PR DESCRIPTION
- Changes to avoid too many renovate dependency update PRs which will unintentionally cause many automatic releases with semantic-release
- Sets renovate to update on a schedule once per week (https://docs.renovatebot.com/presets-schedule/)
- Groups minor updates together in one branch (https://docs.renovatebot.com/presets-group/)
- More detailed configuration is possible if we need it in the future, but for now I've tried to use the preset configs as it makes renovate.json much easier to read