### PR TITLE
Docker Hub auto publish + some Docker refactoring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
     # https://github.community/t/how-do-i-specify-job-dependency-running-in-another-workflow/16482
     if: github.event_name == 'push' && github.ref == 'refs/heads/master' && !contains(github.event.head_commit.message, 'chore(release):')
     runs-on: ubuntu-18.04
+    env:
+      CACHE_IMAGE: sanofiiadc/whispr
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -69,7 +71,18 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Log into Docker registry
+        uses: azure/docker-login@v1
+        with:
+          username: ${{ secrets.SANOFI_DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.SANOFI_DOCKER_HUB_TOKEN }}
+
+      - name: Pull Docker cache image
+        run: docker pull --quiet ${CACHE_IMAGE} 2>/dev/null || true
+
       - name: Semantic Release
         env:
+          MDF_BRANCH_TAG: latest
+          MDF_BUILD_PARAMS: --cache-from ${{ env.CACHE_IMAGE }}
           GH_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
         run: npx semantic-release

--- a/.github/workflows/docker-hub-description.yml
+++ b/.github/workflows/docker-hub-description.yml
@@ -1,0 +1,15 @@
+name: Docker Hub description
+on: release
+jobs:
+  UpdateDockerHubDescription:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Update Docker Hub description
+        uses: peter-evans/dockerhub-description@v2
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.SANOFI_DOCKER_HUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ secrets.SANOFI_DOCKER_HUB_TOKEN }}
+          DOCKERHUB_REPOSITORY: sanofiiadc/whispr

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ lerna-debug.log*
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+# Dockermake
+Makedockfile.dist.conf
+Makedockfile.out

--- a/.releaserc
+++ b/.releaserc
@@ -8,6 +8,9 @@
     ["@semantic-release/npm", {
       "npmPublish": false
     }],
+    ["@semantic-release/exec", {
+      "prepareCmd": "make release branch-tag version-tag"
+    }],
     ["@semantic-release/git", {
       "assets": ["package.json", "CHANGELOG.md"],
       "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,39 @@
-FROM node:12-alpine
-COPY ./ /app
+ARG NODE_VERSION=12.18.1
+
+########################
+# Builder stage
+#
+FROM node:${NODE_VERSION}-alpine AS builder
 WORKDIR /app
-RUN npm config set proxy $HTTP_PROXY
-RUN npm config set https-proxy $HTTPS_PROXY
-RUN npm install
-RUN npm install -g typescript @nestjs/cli
+
+# App build dependencies
+# This step is done before copying and building the app source code
+#  to benefit from Docker layer caching if the dependencies have not changed
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+COPY package*.json ./
+RUN npm ci --quiet
+
+# Copy source code and build
+COPY ./ ./
 RUN npm run build
 
-FROM node:12-alpine
-COPY --from=0 /app /app
+########################
+# Final image
+#
+FROM node:${NODE_VERSION}-alpine
 WORKDIR /app
-RUN npm config set proxy $HTTP_PROXY
-RUN npm config set https-proxy $HTTPS_PROXY
-RUN npm install pm2 -g
+
+# Runtime dependencies
+RUN npm install -g pm2
+
+# App runtime dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+COPY package*.json ./
+RUN npm ci --quiet --only=production
+
+# Build artifacts
+COPY --from=builder /app/pm2.config.js ./pm2.config.js
+COPY --from=builder /app/dist ./dist
+
 EXPOSE 3000
-CMD ["pm2-runtime", "--json", "pm2.config.js"]
+CMD [ "pm2-runtime", "--json", "pm2.config.js" ]

--- a/Makedockfile.conf
+++ b/Makedockfile.conf
@@ -1,0 +1,9 @@
+# Makedockfile global config file
+# https://github.com/Thomvaill/Makedockfile/
+#
+# You can override this file locally by creating Makedockfile.dist.conf
+# To get more help about these variables, see Makefile documentation
+
+MDF_NAMESPACE ?= sanofiiadc
+MDF_REPOSITORY ?= whispr
+MDF_VERSION_TAG ?= $(shell node -e 'console.log(require("./package.json").version || "beta");')

--- a/Makedockfile.dist.example.conf
+++ b/Makedockfile.dist.example.conf
@@ -1,0 +1,5 @@
+# Example Makedockfile.dist.conf file
+# To override locally values of Makedockfile.conf
+
+# Proxy config when building on Docker Desktop for Windows
+MDF_BUILD_PARAMS ?= --build-arg HTTP_PROXY=http://host.docker.internal:3128 --build-arg HTTPS_PROXY=http://host.docker.internal:3128

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,215 @@
+# Makedockfile
+# https://github.com/Thomvaill/Makedockfile/
+#
+# @version 1.0.2
+# @author  Thomvaill (https://github.com/Thomvaill)
+# @license MIT
+#
+# Inspired by https://gist.github.com/mpneuried/0594963ad38e68917ef189b4e6a269db
+#
+
+MDF_MAKEDOCKFILE_VERSION = 1.0.2
+MDF_MAKEDOCKFILE_REPOSITORY = https://github.com/Thomvaill/Makedockfile.git
+
+# CONFIG
+# The following environment variables MUST be set in Makedockfile.conf:
+# - MDF_REPOSITORY   : the Docker repository name, ie the image name
+#
+# The following environment variables SHOULD be set/overriden in Makedockfile.conf, Makedockfile.dist.conf or by an environment variable:
+# - MDF_REGISTRY     : the Docker registry hostname. Useful for private registries. Default: blank
+# - MDF_NAMESPACE    : the Docker namespace name: on Docker Hub it's your username. It can be anything on a private one, or blank. Default: blank
+# - MDF_BRANCH_TAG   : the identifier used to generate the "branch-tag". The result of `git branch` is the default value
+# - MDF_VERSION_TAG  : the identifier used to generate the "version-tag". Disabled by default
+# - MDF_UTAG         : a unique identifier used to tag the current image. Something containing the current commit hash is a good choice!
+#                      Default value: MDF_VERSION_TAG-COMMIT_HASH if MDF_VERSION_TAG is defined,
+#                                     just COMMIT_HASH if not
+#                      You can execute `make print-utag` to see the result
+#
+# - MDF_BUILD_PARAMS : additional parameters to pass to docker build. Some useful ones: --no-cache, --squash...
+# - MDF_RUN_PARAMS   : additional parameters to pass to docker run. Some useful ones: -p, -v...
+# - MDF_RUN_CMD      : to override the default image command
+# - MDF_TEST_PARAMS  : additional parameters to pass to docker run in test mode. Especially used for volumes, to bind-mount test results
+#
+
+# Include Makedockfile[.dist].conf
+-include Makedockfile.dist.conf
+include Makedockfile.conf
+
+# Default values for optional variables
+ifdef MDF_VERSION_TAG
+MDF_UTAG ?= $(MDF_VERSION_TAG)-$(shell git log -1 --pretty=%h)
+else
+MDF_UTAG ?= $(shell git log -1 --pretty=%h)
+endif
+MDF_BRANCH_TAG ?= $(shell git rev-parse --abbrev-ref HEAD | tr / -)
+
+# Private variables
+ifdef MDF_NAMESPACE
+MDF_IMAGE_NAME = $(MDF_NAMESPACE)/$(MDF_REPOSITORY)
+MDF_CONTAINER_NAME = $(MDF_NAMESPACE)_$(MDF_REPOSITORY)
+else
+MDF_IMAGE_NAME = $(MDF_REPOSITORY)
+MDF_CONTAINER_NAME = $(MDF_REPOSITORY)
+endif
+
+ifdef MDF_REGISTRY
+MDF_REGISTRY_IMAGE_NAME = $(MDF_REGISTRY)/$(MDF_IMAGE_NAME)
+else
+MDF_REGISTRY_IMAGE_NAME = $(MDF_IMAGE_NAME)
+endif
+
+MDF_ARTIFACT_PATH = ./Makedockfile.out
+
+
+check_defined = \
+    $(strip $(foreach 1,$1, \
+        $(call __check_defined,$1,$(strip $(value 2)))))
+__check_defined = \
+    $(if $(value $1),, \
+        $(error Undefined $1$(if $2, ($2))$(if $(value @), \
+                required by target `$@')))
+
+
+
+
+#:## Help
+# This will output the help for each task
+# thanks to https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
+.PHONY: help
+
+help: ## This help
+	@awk 'BEGIN { \
+		print "Makedockfile v$(MDF_MAKEDOCKFILE_VERSION)\n\
+	Usage: make \033[36mCOMMAND\033[0m\n\n\
+	Have a look at Makedockfile.conf and Makefile for configuration help\n\
+	You can override configuration in Makedockfile.dist.conf or by passing environment variables directly ";\
+	\
+		FS = ":.*?## "} \
+	/^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2} \
+	/^#:## / {printf "\n\033[35m%s\033[0m\n", $$2} ' \
+	$(MAKEFILE_LIST)
+
+.DEFAULT_GOAL := help
+
+
+
+
+
+#:## Docker tasks for development
+build: ## Build image
+	$(eval MDF_IIDFILE_PATH := $(shell mktemp -t dm-iid-XXXXXX))
+	@echo 'Building $(MDF_IMAGE_NAME)...'
+	docker image build --force-rm=true --iidfile=$(MDF_IIDFILE_PATH) $(MDF_BUILD_PARAMS) -t $(MDF_IMAGE_NAME):latest .
+	@echo "MDF_IMAGE_ID=`cat $(MDF_IIDFILE_PATH)`" > $(MDF_ARTIFACT_PATH)
+	@rm -f $(MDF_IIDFILE_PATH)
+
+run: stop rm ## Run container
+	@echo 'Running $(MDF_CONTAINER_NAME)...'
+	docker container run -it -d --name="$(MDF_CONTAINER_NAME)" $(MDF_RUN_PARAMS) $(MDF_IMAGE_NAME):latest $(MDF_RUN_CMD)
+	@echo '$(MDF_CONTAINER_NAME) now runs in detached mode'
+
+up: build run ## Build image and run container
+
+stop: ## Stop running container
+	@echo 'Stopping $(MDF_CONTAINER_NAME)...'
+	@[ "$$(docker container ls | grep ' $(MDF_CONTAINER_NAME)$$')" ] && docker container stop $(MDF_CONTAINER_NAME) || exit 0
+
+kill: ## Kill running container
+	@echo 'Killing $(MDF_CONTAINER_NAME)...'
+	@[ "$$(docker container ls | grep ' $(MDF_CONTAINER_NAME)$$')" ] && docker container kill $(MDF_CONTAINER_NAME) || exit 0
+
+rm: ## Remove the container
+	@echo 'Removing $(MDF_CONTAINER_NAME)...'
+	@[ "$$(docker container ls -a | grep '$(MDF_CONTAINER_NAME)$$')" ] && docker container rm $(MDF_CONTAINER_NAME) || exit 0
+
+attach: ## Attach to running container
+	docker container attach $(MDF_CONTAINER_NAME)
+
+diff: ## Inspect changes to files or directories on the running container
+	docker container diff $(MDF_CONTAINER_NAME)
+
+bash: ## Start an interactive bash terminal in the running container
+	docker container exec -it $(MDF_CONTAINER_NAME) /bin/bash
+
+sh: ## Start an interactive sh terminal in the running container
+	docker container exec -it $(MDF_CONTAINER_NAME) /bin/sh
+
+pause: ## Pause the running container
+	docker container pause $(MDF_CONTAINER_NAME)
+
+unpause: ## Unpause the paused container
+	docker container unpause $(MDF_CONTAINER_NAME)
+
+restart: ## Restart the running container
+	docker container restart $(MDF_CONTAINER_NAME)
+
+top: ## Display the running processes of the running container
+	docker container top $(MDF_CONTAINER_NAME)
+
+logs: ## Fetch the logs of the running container
+	docker container logs $(MDF_CONTAINER_NAME)
+
+logs-follow: ## Follow running container logs
+	docker container logs --follow $(MDF_CONTAINER_NAME)
+
+test: build ## Build image and run unit tests (Dockerfile.test needed)
+	@echo 'Building test image...'
+	docker image build --force-rm=true -t $(MDF_IMAGE_NAME):test --file Dockerfile.test .
+	@echo 'Running test image...'
+	docker container run $(MDF_TEST_PARAMS) --rm $(MDF_IMAGE_NAME):test
+
+
+
+#:## Docker tasks for CI/CD
+define tag_and_push # from, to
+	docker image tag $(1) $(2)
+	docker image push $(2)
+endef
+
+define append_artifact_file # variable_name, variable_value
+	@echo "$(1)=$(2)" >> $(MDF_ARTIFACT_PATH)
+endef
+
+release: build ## Build image, tag it with a unique identifier and push it to the repository
+	@echo 'Releasing under the tag "$(MDF_UTAG)"...'
+	$(call reset_artifact_file)
+	$(call tag_and_push,$(MDF_IMAGE_NAME):latest,$(MDF_REGISTRY_IMAGE_NAME):$(MDF_UTAG))
+	$(call append_artifact_file,MDF_REGISTRY_IMAGE_NAME,$(MDF_REGISTRY_IMAGE_NAME))
+	$(call append_artifact_file,MDF_UTAG,$(MDF_UTAG))
+
+branch-tag: release ## Add this target to `release` to also tag the released image with the current Git branch name
+	@echo 'Tagging the current release as "$(MDF_BRANCH_TAG)"...'
+	$(call tag_and_push,$(MDF_REGISTRY_IMAGE_NAME):$(MDF_UTAG),$(MDF_REGISTRY_IMAGE_NAME):$(MDF_BRANCH_TAG))
+	$(call append_artifact_file,MDF_BRANCH_TAG,$(MDF_BRANCH_TAG))
+	@echo 'Tagging the current release as "$(MDF_BRANCH_TAG)-$(MDF_UTAG)"...'
+	$(call tag_and_push,$(MDF_REGISTRY_IMAGE_NAME):$(MDF_UTAG),$(MDF_REGISTRY_IMAGE_NAME):$(MDF_BRANCH_TAG)-$(MDF_UTAG))
+	$(call append_artifact_file,MDF_BRANCH_UTAG,$(MDF_BRANCH_TAG)-$(MDF_UTAG))
+
+version-tag: release ## Add this target to `release` to also tag the released image with the version
+	@:$(call check_defined, MDF_VERSION_TAG, required to use `version-tag` target)
+	@echo 'Tagging the current release as "$(MDF_VERSION_TAG)"...'
+	$(call tag_and_push,$(MDF_REGISTRY_IMAGE_NAME):$(MDF_UTAG),$(MDF_REGISTRY_IMAGE_NAME):$(MDF_VERSION_TAG))
+	$(call append_artifact_file,MDF_VERSION_TAG,$(MDF_VERSION_TAG))
+
+
+#:## Misc
+clean: stop rm ## Stop running container and clean related images
+	@echo 'Cleaning related images...'
+	@[ "$$(docker image ls | grep '^$(MDF_IMAGE_NAME) ')" ] && docker image rm $(MDF_IMAGE_NAME):latest || exit 0
+
+print-utag: ## Print the current unique identifier that will be used for `release`
+	@echo $(MDF_UTAG)
+
+print-branch-tag: ## Print the Git branch name that will be used for `branch-tag`
+	@echo $(MDF_BRANCH_TAG)
+
+print-version-tag: ## Print the Git version name that will be used for `version-tag`
+	@:$(call check_defined, MDF_VERSION_TAG, required to use `version-tag` target)
+	@echo $(MDF_VERSION_TAG)
+
+self-update: ## Downloads the latest version of Makedockfile and replace it
+	tmpDir=$$(mktemp -d) \
+	&& git clone --depth=1 $(MDF_MAKEDOCKFILE_REPOSITORY) $$tmpDir \
+	&& cp ./Makefile ./Makefile.bak \
+	&& cp $$tmpDir/src/Makefile ./Makefile \
+	&& rm -rf $$tmpDir

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -31,7 +31,16 @@ services:
       # AWS_CONTAINER_CREDENTIALS_RELATIVE_URI:
       # AWS_S3_ENDPOINT:
       # AWS_BUCKET_NAME:
+    volumes:
+      - ./package.json:/app/package.json:ro
+      - ./package-lock.json:/app/package-lock.json:ro
+      - ./schema.gql:/app/schema.gql
+      - ./tsconfig.build.json:/app/tsconfig.build.json:ro
+      - ./tsconfig.json:/app/tsconfig.json:ro
+      - ./src:/app/src
+      - /app/node_modules
     networks: ["stack"]
+    command: [/bin/sh, -c, "npm ci --quiet && npm run start:dev"]
   mongo1:
     hostname: mongo1
     container_name: localmongo1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,33 @@ services:
     ports:
       - 3000:3000
     working_dir: /usr/share
+    environment:
+      AUTO_SCHEMA_FILE: schema.gql
+      INTROSPECTION: "true"
+      PLAYGROUND: "true"
+      SSL_VALIDATE: "false"
+      REPLICASET: rs0
+      LOG_LEVEL: 5
+      MONGOOSE_HOST: mongo1
+      MONGOOSE_PORT: 27017
+      MONGOOSE_HOST_READ: mongo2
+      MONGOOSE_PORT_READ: 27017
+      # MONGOOSE_USERNAME:
+      # MONGOOSE_PASSWORD:
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      REDIS_HOST_READ: redis
+      REDIS_PORT_READ: 6379
+      # COGNITO_ADMIN_USER:
+      # COGNITO_ADMIN_PW:
+      # COGNITO_USER_POOL_ID:
+      # COGNITO_CLIENT_ID_ADMIN:
+      # COGNITO_REGION:
+      # COGNITO_IDENTITY_POOL_ID:
+      # AWS_CONTAINER_CREDENTIALS_RELATIVE_URI:
+      # AWS_S3_ENDPOINT:
+      # AWS_BUCKET_NAME:
     volumes:
-      - ./local.env:/usr/share/local.env:ro
       - ./package.json:/usr/share/package.json:ro
       - ./schema.gql:/usr/share/schema.gql
       - ./tsconfig.build.json:/usr/share/tsconfig.build.json:ro

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,11 +8,8 @@ Requirements:
 
 ### Configuration
 
-To configure the application, you need to provide a `local.env` file.
-
-::: tip Help
-You can create your `local.env` file from the `example.env` file.
-:::
+Whispr is configured thanks to environment variables in `docker-compose.yml`.
+You can leave the default values for development.
 
 ### Initialize the containers
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6430,6 +6430,125 @@
       "integrity": "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg==",
       "dev": true
     },
+    "@semantic-release/exec": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/exec/-/exec-5.0.0.tgz",
+      "integrity": "sha512-t7LWXIvDJQbuGCy2WmMG51WyaGSLTvZBv9INvcI4S0kn+QjnnVVUMhcioIqhb0r3yqqarMzHVcABFug0q0OXjw==",
+      "dev": true,
+      "requires": {
+        "@semantic-release/error": "^2.1.0",
+        "aggregate-error": "^3.0.0",
+        "debug": "^4.0.0",
+        "execa": "^4.0.0",
+        "lodash": "^4.17.4",
+        "parse-json": "^5.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "execa": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.2.tgz",
+          "integrity": "sha512-QI2zLa6CjGWdiQsmSkZoGtDx2N+cQIGb3yNolGTdjSQzydzLgYYf8LRuagp7S7fPimjcrzUDSUFd/MgzELMi4Q==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "@semantic-release/git": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@semantic-release/git/-/git-9.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@nestjs/schematics": "7.0.1",
     "@nestjs/testing": "7.2.0",
     "@semantic-release/changelog": "5.0.1",
+    "@semantic-release/exec": "^5.0.0",
     "@semantic-release/git": "9.0.0",
     "@semantic-release/github": "7.0.7",
     "@types/express": "4.17.6",


### PR DESCRIPTION
- Make whispr completely configurable from environment variables because we don't want to mount a `.env` file inside Docker images
- `Dockerfile` completely refactored:
  - No more dev dependencies in the final image
  - Use Docker layer caching, especially for NPM dependencies
  - Remove proxy config that should be defined in the CLI instead
- CI to build & push automatically to Docker Hub
- Automatically update Docker Hub description on each release
- Separate the quick-start `docker-compose.yml` from the DEV one

From now on, developers should use `docker-compose.dev.yml` instead of `docker-compose.yml`: `docker-compose -f docker-compose.dev.yml ...`