### PR TITLE
chore(renovate): Set scope of semantic commits

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,7 @@
     ":automergeLinters",
     ":automergeTypes",
     ":automergePatch",
-    ":semanticCommits"
+    ":semanticCommits",
+    "semanticCommitScope": "dependency maintenance"
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
     ":automergeLinters",
     ":automergeTypes",
     ":automergePatch",
-    ":semanticCommits",
-    "semanticCommitScope": "dependency maintenance"
-  ]
+    ":semanticCommits"
+  ],
+  "semanticCommitScope": "dependency maintenance"
 }


### PR DESCRIPTION
Updates renovate config so that scope of commits is **dependency maintenance**.

The goal is to workaround the current problem that because dependency updates are technically fixes (or at least there's no more suitable standard conventional commit type), they currently appear in the Bug Fixes section of the changelog. This is confusing because it gives the impression that there was a bug but it's not actually the case, so this PR aims to more explicitly show that it's maintenance and not a bug.

This means that:
- Dev dependency updates will have the format chore(dependency maintenance): updated packageX to v1.2.3
- Build dependency updates will have the format fix(dependency maintenance): updated packageX to v1.2.3

So in the future the changelog will show this:
### Bug Fixes
**dependency maintenance:** update dependency aws-sdk to v2.706.0 (f6d8496)
**dependency maintenance:** update dependency aws-sdk to v2.707.0 (bfbd940)

instead of this:
### Bug Fixes
**deps:** update dependency aws-sdk to v2.706.0 (f6d8496)
**deps:** update dependency aws-sdk to v2.707.0 (bfbd940)

