### PR TITLE
ci: fix Docker Hub readme update & better trigger

### DIFF
--- a/.github/workflows/docker-hub-description.yml
+++ b/.github/workflows/docker-hub-description.yml
@@ -1,5 +1,10 @@
 name: Docker Hub description
-on: release
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - README.md
 jobs:
   UpdateDockerHubDescription:
     runs-on: ubuntu-18.04
@@ -11,5 +16,5 @@ jobs:
         uses: peter-evans/dockerhub-description@v2
         env:
           DOCKERHUB_USERNAME: ${{ secrets.SANOFI_DOCKER_HUB_USERNAME }}
-          DOCKERHUB_PASSWORD: ${{ secrets.SANOFI_DOCKER_HUB_TOKEN }}
+          DOCKERHUB_PASSWORD: ${{ secrets.SANOFI_DOCKER_HUB_PASSWORD }}
           DOCKERHUB_REPOSITORY: sanofiiadc/whispr


### PR DESCRIPTION
- better trigger: triggered when README.md is updated on master
- fix the API auth issue: uses the password instead of the token (because https://github.com/docker/hub-feedback/issues/1927)