### PR TITLE
fix: docDB SSL_VALIDATE option

### DIFF
--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -66,7 +66,7 @@ export class ConfigService {
       useNewUrlParser: true,
       useUnifiedTopology: true,
     };
-    if (this.get('SSL_VALIDATE') === 'true') {
+    if (this.get('SSL_VALIDATE') === true) {
       const ca = fs.readFileSync(this.get('PATH_TO_SSL_CERTIFICATE'));
       options.server = {
         ssl: true,


### PR DESCRIPTION
Joi casts this option value as an actual boolean

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix for Mongo, especially when using AWS Document DB which requires a custom SSL cert.


* **What is the current behavior?** (You can also link to an open issue here)
`SSL_VALIDATE` environment variable is never taken into account


* **What is the new behavior (if this is a feature change)?**
`SSL_VALIDATE` environment variable is taken into account


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
