### PR TITLE
chore: update fastify-compress to match fastify version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13315,9 +13315,9 @@
       "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g=="
     },
     "buffer-indexof-polyfill": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.1.tgz",
-      "integrity": "sha1-qfuAbOgUXVQoUQznLyeLs2OmOL8="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A=="
     },
     "buffer-json": {
       "version": "2.0.0",
@@ -17464,24 +17464,44 @@
       }
     },
     "fastify-compress": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fastify-compress/-/fastify-compress-1.1.0.tgz",
-      "integrity": "sha512-/2vaaPWpORFWq5YrvpDBImEIes4M9oNlRNJLbrmbzVsJwiMTVl43W9ciTG6AFmb7N9oRCnQVTKSG9C64hjPcBw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/fastify-compress/-/fastify-compress-3.3.0.tgz",
+      "integrity": "sha512-g/q7g9JaN14pVe7Op8zwKD/MxyBBXjLkK8Y6UtcwRDwufAlqLO1jZ/srM5JTly5AKnXPnX6ft9Nz/83xYNltrQ==",
       "requires": {
         "encoding-negotiator": "^2.0.0",
-        "fastify-plugin": "^1.0.0",
-        "into-stream": "4.0.0",
+        "fastify-plugin": "^2.2.0",
+        "into-stream": "^5.1.1",
         "is-deflate": "^1.0.0",
-        "is-gzip": "^1.0.0",
+        "is-gzip": "^2.0.0",
         "is-stream": "^2.0.0",
         "is-zip": "^1.0.0",
-        "mime-db": "^1.33.0",
-        "minipass": "^2.9.0",
+        "mime-db": "^1.43.0",
+        "minipass": "^3.1.1",
         "peek-stream": "^1.1.0",
         "pump": "^3.0.0",
-        "pumpify": "^2.0.0",
+        "pumpify": "^2.0.1",
         "string-to-stream": "^3.0.0",
-        "unzipper": "^0.10.1"
+        "unzipper": "^0.10.8"
+      },
+      "dependencies": {
+        "fastify-plugin": {
+          "version": "2.3.4",
+          "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-2.3.4.tgz",
+          "integrity": "sha512-I+Oaj6p9oiRozbam30sh39BiuiqBda7yK2nmSPVwDCfIBlKnT8YB3MY+pRQc2Fcd07bf6KPGklHJaQ2Qu81TYQ==",
+          "requires": {
+            "semver": "^7.3.2"
+          }
+        },
+        "mime-db": {
+          "version": "1.44.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+          "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+        }
       }
     },
     "fastify-cors": {
@@ -19834,12 +19854,12 @@
       "dev": true
     },
     "into-stream": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-4.0.0.tgz",
-      "integrity": "sha512-i29KNyE5r0Y/UQzcQ0IbZO1MYJ53Jn0EcFRZPj5FzWKYH17kDFEOwuA+3jroymOI06SW1dEDnly9A1CAreC5dg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-5.1.1.tgz",
+      "integrity": "sha512-krrAJ7McQxGGmvaYbB7Q1mcA+cRwg9Ij2RfWIeVesNBgVDZmzY/Fa4IpZUT3bmdRzMzdf/mzltCG2Dq99IZGBA==",
       "requires": {
-        "from2": "^2.1.1",
-        "p-is-promise": "^2.0.0"
+        "from2": "^2.3.0",
+        "p-is-promise": "^3.0.0"
       }
     },
     "invariant": {
@@ -20082,9 +20102,9 @@
       }
     },
     "is-gzip": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz",
-      "integrity": "sha1-bKiwe5nHeZgCWQDlVc7Y7YCHmoM="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-2.0.0.tgz",
+      "integrity": "sha512-jtO4Njg6q58zDo/Pu4027beSZ0VdsZlt8/5Moco6yAg+DIxb5BK/xUYqYG2+MD4+piKldXJNHxRkhEYI2fvrxA=="
     },
     "is-installed-globally": {
       "version": "0.3.2",
@@ -24810,12 +24830,18 @@
       }
     },
     "minipass": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+      "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
       "requires": {
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.0"
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
       }
     },
     "minipass-collect": {
@@ -29947,9 +29973,9 @@
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-3.0.0.tgz",
+      "integrity": "sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ=="
     },
     "p-limit": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "cross-fetch": "3.0.5",
     "dotenv": "8.2.0",
     "express": "4.17.1",
-    "fastify-compress": "1.1.0",
+    "fastify-compress": "3.3.0",
     "file-type": "14.7.1",
     "graphql": "15.3.0",
     "graphql-redis-subscriptions": "2.2.2",


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Update `fastify-compress` to `3.3.0` because it breaks the build with `fastify` version `3.1.1` introduced by commit [29e4d69](https://github.com/Sanofi-IADC/whispr/commit/29e4d69e2a2446fe2d8dfecac8acbce6bb359859#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R34) 

* **What is the current behavior?** (You can also link to an open issue here)

[Broken build](https://github.com/Sanofi-IADC/whispr/runs/1020142705#step:8:173) because of TypeScript error


* **What is the new behavior (if this is a feature change)?**

Build fixed

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
