### PR TITLE
fix(webhooks): set https-Agent to correctly use Proxy & CA_Certificat…

### DIFF
--- a/docs/webhooks/readme.md
+++ b/docs/webhooks/readme.md
@@ -40,3 +40,11 @@ In the case of our example above, it would be:
      "content": whispEntity
  }
  ```
+
+### Webhook proxy / CA
+
+In order to use a proxy or a custom CA in your webhook calls, the respective environment variables have to be set.
+These are: 
+* HTTP_PROXY
+* HTTPS_PROXY
+* CA_CERTIFICATE

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanofi/whispr",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6300,6 +6300,15 @@
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.6.tgz",
       "integrity": "sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==",
       "dev": true
+    },
+    "@types/tunnel": {
+      "version": "0.0.1",
+      "resolved": "https://emea-aws-eccs-nexus-dev.service.cloud.local:3092/repository/npm_group/@types/tunnel/-/tunnel-0.0.1.tgz",
+      "integrity": "sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/uglify-js": {
       "version": "3.11.1",
@@ -30016,6 +30025,11 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
+    },
+    "tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://emea-aws-eccs-nexus-dev.service.cloud.local:3092/repository/npm_group/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "amazon-cognito-identity-js": "4.3.4",
     "apollo-server-fastify": "2.15.1",
     "aws-sdk": "2.707.0",
-    "axios": "0.19.2",
     "class-transformer": "0.3.1",
     "class-validator": "0.12.2",
     "cross-fetch": "3.0.5",
@@ -63,6 +62,7 @@
     "superagent": "5.2.2",
     "superagent-promise": "1.1.0",
     "superagent-proxy": "2.0.0",
+    "tunnel": "0.0.6",
     "vuepress": "1.5.4"
   },
   "devDependencies": {
@@ -82,6 +82,7 @@
     "@types/node": "12.12.7",
     "@types/socket.io": "2.1.11",
     "@types/supertest": "2.0.10",
+    "@types/tunnel": "0.0.1",
     "@typescript-eslint/eslint-plugin": "3.5.0",
     "@typescript-eslint/parser": "3.5.0",
     "cz-conventional-changelog": "3.2.0",

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -79,7 +79,7 @@ export class ConfigService {
     return options;
   }
 
-  getProxyConfig(): { host: string, port: number } | undefined {
+  getProxyConfig(): { host: string; port: number } | undefined {
     const proxy = this.get('HTTP_PROXY') || this.get('HTTPS_PROXY');
     if (!proxy) {
       return undefined;
@@ -87,7 +87,8 @@ export class ConfigService {
     const host = proxy.split(':')[1].slice(2);
     const port = parseInt(proxy.split(':')[2], 10);
     return {
-      host, port,
+      host,
+      port,
     };
   }
 

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -79,6 +79,18 @@ export class ConfigService {
     return options;
   }
 
+  getProxyConfig(): { host: string, port: number } | undefined {
+    const proxy = this.get('HTTP_PROXY') || this.get('HTTPS_PROXY');
+    if (!proxy) {
+      return undefined;
+    }
+    const host = proxy.split(':')[1].slice(2);
+    const port = parseInt(proxy.split(':')[2], 10);
+    return {
+      host, port,
+    };
+  }
+
   getLogLevel(): any {
     return this.logLevels.slice(0, this.get('LOG_LEVEL'));
   }

--- a/src/config/environmentValidationSchema.ts
+++ b/src/config/environmentValidationSchema.ts
@@ -41,4 +41,8 @@ export default Joi.object({
   AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: Joi.string(),
   AWS_S3_ENDPOINT: Joi.string(),
   AWS_BUCKET_NAME: Joi.string(),
+
+  HTTP_PROXY: Joi.string(),
+  HTTPS_PROXY: Joi.string(),
+  CA_CERTIFICATE: Joi.string(),
 });

--- a/src/event/event.service.ts
+++ b/src/event/event.service.ts
@@ -54,7 +54,11 @@ export class EventService {
 
     webhooks.forEach((webhook) => {
       webhook.events.forEach((eventName) => {
-        this.registerListener(eventName, WebhookService.getCallFunction(webhook), webhook.filter);
+        this.registerListener(
+          eventName,
+          this.webhookService.getCallFunction(webhook),
+          webhook.filter,
+        );
       });
     });
   }

--- a/src/webhook/webhook.module.ts
+++ b/src/webhook/webhook.module.ts
@@ -1,15 +1,35 @@
-import { Module } from '@nestjs/common';
+import { HttpModule, Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
 
+import * as tunnel from 'tunnel';
+import { ConfigModule } from '../config/config.module';
 import { WebhookController } from './webhook.controller';
 import { WebhookService } from './webhook.service';
 import { webhookSchema } from './webhook.schema';
 import { WebhookResolver } from './webhook.resolver';
+import { ConfigService } from '../config/config.service';
 
 @Module({
-  imports: [MongooseModule.forFeature([{ name: 'Webhook', schema: webhookSchema }])],
+  imports: [
+    MongooseModule.forFeature([{ name: 'Webhook', schema: webhookSchema }]),
+    HttpModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => ({
+        proxy: false,
+        httpsAgent: tunnel.httpsOverHttp({
+          ca: configService.get('CA_CERTIFICATE') ? [Buffer.from(configService.get('CA_CERTIFICATE'))] : undefined,
+          proxy: configService.getProxyConfig(),
+        }),
+      }),
+    }),
+  ],
   controllers: [WebhookController],
-  providers: [WebhookService, WebhookResolver],
+  providers: [
+    WebhookService,
+    WebhookResolver,
+    ConfigService,
+  ],
   exports: [WebhookService],
 })
-export class WebhookModule {}
+export class WebhookModule { }

--- a/src/webhook/webhook.module.ts
+++ b/src/webhook/webhook.module.ts
@@ -18,18 +18,16 @@ import { ConfigService } from '../config/config.service';
       useFactory: (configService: ConfigService) => ({
         proxy: false,
         httpsAgent: tunnel.httpsOverHttp({
-          ca: configService.get('CA_CERTIFICATE') ? [Buffer.from(configService.get('CA_CERTIFICATE'))] : undefined,
+          ca: configService.get('CA_CERTIFICATE')
+            ? [Buffer.from(configService.get('CA_CERTIFICATE'))]
+            : undefined,
           proxy: configService.getProxyConfig(),
         }),
       }),
     }),
   ],
   controllers: [WebhookController],
-  providers: [
-    WebhookService,
-    WebhookResolver,
-    ConfigService,
-  ],
+  providers: [WebhookService, WebhookResolver, ConfigService],
   exports: [WebhookService],
 })
-export class WebhookModule { }
+export class WebhookModule {}

--- a/src/webhook/webhook.service.ts
+++ b/src/webhook/webhook.service.ts
@@ -12,7 +12,7 @@ export class WebhookService {
   constructor(
     @InjectModel('Webhook') private readonly webhookModel: Model<IWebhook>,
     private readonly httpService: HttpService,
-  ) { }
+  ) {}
 
   async create(webhook: WebhookInputType): Promise<IWebhook> {
     return this.webhookModel.create(webhook);
@@ -36,7 +36,8 @@ export class WebhookService {
         .post(webhook.url, {
           eventName: event.name,
           content: event.payload,
-        }).toPromise()
+        })
+        .toPromise()
         .then(
           (response) => {
             Logger.log(

--- a/src/webhook/webhook.service.ts
+++ b/src/webhook/webhook.service.ts
@@ -3,7 +3,6 @@ import {
 } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
-import { ConfigService } from '../config/config.service';
 import { IWebhook } from '../interfaces/webhook.interface';
 import { Event } from '../event/event.entity';
 import { WebhookInputType } from './webhook.input';

--- a/tests/unit/utils/configService.spec.ts
+++ b/tests/unit/utils/configService.spec.ts
@@ -7,7 +7,7 @@ describe('ConfigService', () => {
   });
   describe('get', () => {
     beforeEach(() => {
-      process.env.HTTPS_PROXY = 'http://test.proxxy.com:3128';
+      process.env.HTTPS_PROXY = 'http://test.proxy.com:3128';
       configService = new ConfigService();
     });
     it('should return var from process.env', () => {
@@ -26,12 +26,12 @@ describe('ConfigService', () => {
   describe('getProxyConfig', () => {
     describe('with proxy set', () => {
       beforeEach(() => {
-        process.env.HTTPS_PROXY = 'http://test.proxxy.com:3128';
+        process.env.HTTPS_PROXY = 'http://test.proxy.com:3128';
         configService = new ConfigService();
       });
       it('should return proxy config', () => {
         const expectedResult = {
-          host: 'test.proxxy.com',
+          host: 'test.proxy.com',
           port: 3128,
         };
         const result = configService.getProxyConfig();

--- a/tests/unit/utils/configService.spec.ts
+++ b/tests/unit/utils/configService.spec.ts
@@ -1,0 +1,52 @@
+import { ConfigService } from '../../../src/config/config.service';
+
+describe('ConfigService', () => {
+  let configService: ConfigService;
+  beforeEach(() => {
+    process.env.NODE_ENV = 'example';
+  });
+  describe('get', () => {
+    beforeEach(() => {
+      process.env.HTTPS_PROXY = 'http://test.proxxy.com:3128';
+      configService = new ConfigService();
+    });
+    it('should return var from process.env', () => {
+      const proxy = configService.get('HTTPS_PROXY');
+      expect(proxy).toEqual(process.env.HTTPS_PROXY);
+    });
+    it('should return var from config-file', () => {
+      const proxy = configService.get('MONGOOSE_HOST');
+      expect(proxy).toEqual('mongo1');
+    });
+    it('should return undefined if var is not set', () => {
+      const result = configService.get('HTTP_PROXY');
+      expect(result).toBeUndefined();
+    });
+  });
+  describe('getProxyConfig', () => {
+    describe('with proxy set', () => {
+      beforeEach(() => {
+        process.env.HTTPS_PROXY = 'http://test.proxxy.com:3128';
+        configService = new ConfigService();
+      });
+      it('should return proxy config', () => {
+        const expectedResult = {
+          host: 'test.proxxy.com',
+          port: 3128,
+        };
+        const result = configService.getProxyConfig();
+        expect(result).toEqual(expectedResult);
+      });
+    });
+    describe('without proxy set', () => {
+      beforeEach(() => {
+        delete process.env.HTTPS_PROXY;
+        configService = new ConfigService();
+      });
+      it('should return undefined', () => {
+        const result = configService.getProxyConfig();
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+});


### PR DESCRIPTION
…e for Webhook calls

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug-Fix


* **What is the current behavior?** (You can also link to an open issue here)
Webhook calls fail due to issues with the proxy settings.
https://github.com/axios/axios/issues/2072


* **What is the new behavior (if this is a feature change)?**
Uses tunnel to send webhook calls which:
1. Allows definition of custom CA
2. Allows definition of proxy


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
None
If custom CA is required, pass the certificate as an environment var CA_CERTIFICATE.


* **Other information**:
