### PR TITLE
fix(webhook): disable errors in certificate chain for webhooks

### DIFF
--- a/src/webhook/webhook.module.ts
+++ b/src/webhook/webhook.module.ts
@@ -22,7 +22,8 @@ import { ConfigService } from '../config/config.service';
             ? [fs.readFileSync(configService.get('CA_CERTIFICATE_PATH'))]
             : undefined,
           proxy: configService.getProxyConfig(),
-        }),
+          rejectUnauthorized: false,
+        } as any),
       }),
     }),
   ],


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Webhooks fail for some self-signed certificates


* **What is the new behavior (if this is a feature change)?**
Webhook will no longer fail when there is a self-signed certificate in the chain


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
