### PR TITLE
test(config-service): fixed test of configService to work even when H…

### DIFF
--- a/tests/unit/utils/configService.spec.ts
+++ b/tests/unit/utils/configService.spec.ts
@@ -1,14 +1,24 @@
 import * as tunnel from 'tunnel';
 import { ConfigService } from '../../../src/config/config.service';
 
+const httpProxy = process.env.HTTP_PROXY;
+const httpsProxy = process.env.HTTPS_PROXY;
+
 describe('ConfigService', () => {
   let configService: ConfigService;
-  beforeEach(() => {
+  beforeAll(() => {
     process.env.NODE_ENV = 'example';
+    delete process.env.HTTP_PROXY;
+    delete process.env.HTTPS_PROXY;
+  });
+  afterAll(() => {
+    process.env.HTTP_PROXY = httpProxy;
+    process.env.HTTPS_PROXY = httpsProxy;
   });
   describe('get', () => {
     beforeEach(() => {
       process.env.HTTPS_PROXY = 'http://test.proxy.com:3128';
+      delete process.env.HTTP_PROXY;
       configService = new ConfigService();
     });
     it('should return var from process.env', () => {
@@ -45,6 +55,7 @@ describe('ConfigService', () => {
     describe('without proxy set', () => {
       beforeEach(() => {
         delete process.env.HTTPS_PROXY;
+        delete process.env.HTTP_PROXY;
         configService = new ConfigService();
       });
       it('should return undefined', () => {


### PR DESCRIPTION
…TTP_PROXY is set as env-var

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Test


* **What is the current behavior?** (You can also link to an open issue here)
Tests fail when HTTP_PROXY is set as env var while executing the tests


* **What is the new behavior (if this is a feature change)?**
Tests succeed even when HTTP_PROXY is set as env var


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
