### PR TITLE
fix(instana): force import of instana first

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanofi/whispr",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,14 @@
+/* eslint-disable import/first */
+if (process.env.NODE_ENV !== 'local' && process.env.NODE_ENV !== 'test' && process.env.INSTANA_ENDPOINT_URL) {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
+  require('@instana/collector')();
+}
+
 import { NestFactory } from '@nestjs/core';
 import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
 import Fastify from 'fastify-compress';
 import { AppModule } from './app.module';
 import { ConfigService } from './config/config.service';
-
-if (process.env.NODE_ENV !== 'local' && process.env.NODE_ENV !== 'test' && process.env.INSTANA_ENDPOINT_URL) {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
-  require('@instana/collector')();
-}
 
 const configService = new ConfigService();
 


### PR DESCRIPTION
- Fix to force import of Instana collector before other imports (ignore eslint rule)
- This is a requirement according to Instana documentation: https://www.instana.com/docs/ecosystem/node-js/#installation