### PR TITLE
Feature/extendedwebhookfilter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanofi-iadc/whispr",
-  "version": "3.1.14",
+  "version": "3.1.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4123,6 +4123,37 @@
           "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
           "dev": true
         }
+      }
+    },
+    "@ucast/core": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@ucast/core/-/core-1.10.1.tgz",
+      "integrity": "sha512-sXKbvQiagjFh2JCpaHUa64P4UdJbOxYeC5xiZFn8y6iYdb0WkismduE+RmiJrIjw/eLDYmIEXiQeIYYowmkcAw=="
+    },
+    "@ucast/js": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@ucast/js/-/js-3.0.2.tgz",
+      "integrity": "sha512-zxNkdIPVvqJjHI7D/iK8Aai1+59yqU+N7bpHFodVmiTN7ukeNiGGpNmmSjQgsUw7eNcEBnPrZHNzp5UBxwmaPw==",
+      "requires": {
+        "@ucast/core": "^1.0.0"
+      }
+    },
+    "@ucast/mongo": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@ucast/mongo/-/mongo-2.4.2.tgz",
+      "integrity": "sha512-/zH1TdBJlYGKKD+Wh0oyD+aBvDSWrwHcD8b4tUL9UgHLhzHtkEnMVFuxbw3SRIRsAa01wmy06+LWt+WoZdj1Bw==",
+      "requires": {
+        "@ucast/core": "^1.4.1"
+      }
+    },
+    "@ucast/mongo2js": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ucast/mongo2js/-/mongo2js-1.3.3.tgz",
+      "integrity": "sha512-sBPtMUYg+hRnYeVYKL+ATm8FaRPdlU9PijMhGYKgsPGjV9J4Ks41ytIjGayvKUnBOEhiCaKUUnY4qPeifdqATw==",
+      "requires": {
+        "@ucast/core": "^1.6.1",
+        "@ucast/js": "^3.0.0",
+        "@ucast/mongo": "^2.4.0"
       }
     },
     "@vue/babel-helper-vue-jsx-merge-props": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4125,37 +4125,6 @@
         }
       }
     },
-    "@ucast/core": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@ucast/core/-/core-1.10.1.tgz",
-      "integrity": "sha512-sXKbvQiagjFh2JCpaHUa64P4UdJbOxYeC5xiZFn8y6iYdb0WkismduE+RmiJrIjw/eLDYmIEXiQeIYYowmkcAw=="
-    },
-    "@ucast/js": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@ucast/js/-/js-3.0.2.tgz",
-      "integrity": "sha512-zxNkdIPVvqJjHI7D/iK8Aai1+59yqU+N7bpHFodVmiTN7ukeNiGGpNmmSjQgsUw7eNcEBnPrZHNzp5UBxwmaPw==",
-      "requires": {
-        "@ucast/core": "^1.0.0"
-      }
-    },
-    "@ucast/mongo": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@ucast/mongo/-/mongo-2.4.2.tgz",
-      "integrity": "sha512-/zH1TdBJlYGKKD+Wh0oyD+aBvDSWrwHcD8b4tUL9UgHLhzHtkEnMVFuxbw3SRIRsAa01wmy06+LWt+WoZdj1Bw==",
-      "requires": {
-        "@ucast/core": "^1.4.1"
-      }
-    },
-    "@ucast/mongo2js": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@ucast/mongo2js/-/mongo2js-1.3.3.tgz",
-      "integrity": "sha512-sBPtMUYg+hRnYeVYKL+ATm8FaRPdlU9PijMhGYKgsPGjV9J4Ks41ytIjGayvKUnBOEhiCaKUUnY4qPeifdqATw==",
-      "requires": {
-        "@ucast/core": "^1.6.1",
-        "@ucast/js": "^3.0.0",
-        "@ucast/mongo": "^2.4.0"
-      }
-    },
     "@vue/babel-helper-vue-jsx-merge-props": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@vue/babel-helper-vue-jsx-merge-props/-/babel-helper-vue-jsx-merge-props-1.2.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16712,6 +16712,11 @@
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true
     },
+    "mingo": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/mingo/-/mingo-6.0.3.tgz",
+      "integrity": "sha512-7unu3kus/ELdE+hQ+iEoMGv3eKLuP6YTugOFgqCltlahudkm0rRXUNM9+2ynyd146xEsAbn0xpd7Jhz3Dl5cXA=="
+    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -17090,6 +17095,11 @@
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
           "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "sift": {
+          "version": "13.5.2",
+          "resolved": "https://registry.npmjs.org/sift/-/sift-13.5.2.tgz",
+          "integrity": "sha512-+gxdEOMA2J+AI+fVsCqeNn7Tgx3M9ZN9jdi95939l1IJ8cZsqS8sqpJyOkic2SJk+1+98Uwryt/gL6XDaV+UZA=="
         }
       }
     },
@@ -24220,11 +24230,6 @@
         "get-intrinsic": "^1.0.2",
         "object-inspect": "^1.9.0"
       }
-    },
-    "sift": {
-      "version": "13.5.2",
-      "resolved": "https://registry.npmjs.org/sift/-/sift-13.5.2.tgz",
-      "integrity": "sha512-+gxdEOMA2J+AI+fVsCqeNn7Tgx3M9ZN9jdi95939l1IJ8cZsqS8sqpJyOkic2SJk+1+98Uwryt/gL6XDaV+UZA=="
     },
     "signal-exit": {
       "version": "3.0.6",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@nestjs/websockets": "8.2.3",
     "@typegoose/typegoose": "8.3.0",
     "@types/graphql": "14.5.0",
-    "@ucast/mongo2js": "^1.3.3",
     "amazon-cognito-identity-js": "5.2.3",
     "apollo-server-core": "3.5.0",
     "apollo-server-fastify": "3.5.0",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "ioredis": "4.28.2",
     "joi": "17.5.0",
     "lodash": "4.17.21",
+    "mingo": "^6.0.3",
     "mongoose": "5.13.13",
     "mongoose-cast-aggregation": "0.2.1",
     "reflect-metadata": "0.1.13",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@nestjs/websockets": "8.2.3",
     "@typegoose/typegoose": "8.3.0",
     "@types/graphql": "14.5.0",
+    "@ucast/mongo2js": "^1.3.3",
     "amazon-cognito-identity-js": "5.2.3",
     "apollo-server-core": "3.5.0",
     "apollo-server-fastify": "3.5.0",

--- a/src/event/event.service.ts
+++ b/src/event/event.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { Condition, interpret } from '@ucast/mongo2js';
+import { filterPayload } from '../utils/filterPayload.service';
 import { WebhookService } from '../webhook/webhook.service';
 import { IListener, ListenerCallback } from '../interfaces/listener.interface';
 import { Event, EventNames } from './event.entity';
@@ -19,7 +19,7 @@ export class EventService {
     const listeners = this.registeredListeners[event.name];
 
     listeners.forEach((listener) => {
-      if (interpret(listener.filter as unknown as Condition, event.payload)) {
+      if (filterPayload(listener.filter, event.payload)) {
         listener.callback(event);
       }
     });

--- a/src/event/event.service.ts
+++ b/src/event/event.service.ts
@@ -59,7 +59,7 @@ export class EventService {
     });
   }
 
-  private registerListener(eventName: string, callback: ListenerCallback, filter: Record<string, unknown> = {}) {
+  private registerListener(eventName: string, callback: ListenerCallback, filter: Record<string, unknown> | string = {}) {
     if (!EventService.doesEventExist(eventName)) {
       Logger.error(`Could not register listener, Event ${eventName} does not exist.`);
       return;

--- a/src/event/event.service.ts
+++ b/src/event/event.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { Condition, interpret } from '@ucast/mongo2js';
 import { WebhookService } from '../webhook/webhook.service';
 import { IListener, ListenerCallback } from '../interfaces/listener.interface';
-import { filterPayload } from '../utils/filterPayload.service';
 import { Event, EventNames } from './event.entity';
 
 export const pluginNames = [];
@@ -19,7 +19,7 @@ export class EventService {
     const listeners = this.registeredListeners[event.name];
 
     listeners.forEach((listener) => {
-      if (filterPayload(listener.filter, event.payload)) {
+      if (interpret(listener.filter as unknown as Condition, event.payload)) {
         listener.callback(event);
       }
     });

--- a/src/interfaces/listener.interface.ts
+++ b/src/interfaces/listener.interface.ts
@@ -4,5 +4,5 @@ export type ListenerCallback = (event: Event) => Promise<void>;
 
 export interface IListener {
   callback: ListenerCallback;
-  filter: Record<string, unknown>;
+  filter: Record<string, unknown> | string;
 }

--- a/src/interfaces/webhook.interface.ts
+++ b/src/interfaces/webhook.interface.ts
@@ -3,5 +3,5 @@ import { Document } from 'mongoose';
 export interface IWebhook extends Document {
   url: string;
   events: string[];
-  filter: Record<string, unknown>;
+  filter: string;
 }

--- a/src/webhook/webhook.service.ts
+++ b/src/webhook/webhook.service.ts
@@ -3,6 +3,7 @@ import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { stringify } from 'flatted';
 import { HttpService } from '@nestjs/axios';
+import { guard } from '@ucast/mongo2js';
 import { IWebhook } from '../interfaces/webhook.interface';
 import { Event } from '../event/event.entity';
 import { WebhookInputType } from './webhook.input';
@@ -15,7 +16,9 @@ export class WebhookService {
   ) {}
 
   async create(webhook: WebhookInputType): Promise<IWebhook> {
-    return this.webhookModel.create(webhook);
+    const test = guard(webhook.filter);
+    const newHook = { ...webhook, filter: test.ast };
+    return this.webhookModel.create(newHook);
   }
 
   async findAll(): Promise<IWebhook[]> {

--- a/src/webhook/webhook.service.ts
+++ b/src/webhook/webhook.service.ts
@@ -3,7 +3,7 @@ import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { stringify } from 'flatted';
 import { HttpService } from '@nestjs/axios';
-import { guard } from '@ucast/mongo2js';
+import { allParsingInstructions, MongoQueryParser } from '@ucast/mongo2js';
 import { IWebhook } from '../interfaces/webhook.interface';
 import { Event } from '../event/event.entity';
 import { WebhookInputType } from './webhook.input';
@@ -16,8 +16,9 @@ export class WebhookService {
   ) {}
 
   async create(webhook: WebhookInputType): Promise<IWebhook> {
-    const test = guard(webhook.filter);
-    const newHook = { ...webhook, filter: test.ast };
+    const parser = new MongoQueryParser(allParsingInstructions);
+    const ast = parser.parse(webhook.filter);
+    const newHook = { ...webhook, filter: ast };
     return this.webhookModel.create(newHook);
   }
 

--- a/tests/unit/utils/filterPayload.service.spec.ts
+++ b/tests/unit/utils/filterPayload.service.spec.ts
@@ -1,45 +1,85 @@
-import { filterPayload, payloadMatchesNestedValue } from '../../../src/utils/filterPayload.service';
+import {
+  filterPayload,
+} from '../../../src/utils/filterPayload.service';
 
 describe('WhispFilter', () => {
   describe('filter', () => {
     it('should return false if there is no value attach to the filter key', () => {
-      expect(filterPayload({ aKey: undefined }, { aKey: 'aValue' })).toEqual(false);
+      expect(filterPayload({ aKey: undefined }, { aKey: 'aValue' })).toEqual(
+        false,
+      );
     });
     it('should return false if there is no payload', () => {
       expect(filterPayload({ aKey: 'a value' }, undefined)).toEqual(false);
     });
     it('should return false if there is no corresponding key in the payload', () => {
-      expect(filterPayload({ aKey: 'aValue' }, { notTheSameKey: 'aValue' })).toEqual(false);
+      expect(
+        filterPayload({ aKey: 'aValue' }, { notTheSameKey: 'aValue' }),
+      ).toEqual(false);
     });
     it('should return true if all conditions are true', () => {
       expect(
-        filterPayload({ aKey: 'aValue', anotherKey: 'anotherValue' }, { aKey: 'aValue', anotherKey: 'anotherValue' }),
+        filterPayload(
+          { aKey: 'aValue', anotherKey: 'anotherValue' },
+          { aKey: 'aValue', anotherKey: 'anotherValue' },
+        ),
       ).toEqual(true);
     });
     it('should return false if all conditions are not true', () => {
       expect(
-        filterPayload({ aKey: 'aValue', anotherKey: 'anotherValue' }, { aKey: 'aValue', anotherKey: 'notTheExpectedValue' }),
+        filterPayload(
+          { aKey: 'aValue', anotherKey: 'anotherValue' },
+          { aKey: 'aValue', anotherKey: 'notTheExpectedValue' },
+        ),
       ).toEqual(false);
     });
     it('should go recursive and return true if all conditions are true', () => {
-      expect(filterPayload({ aKey: { anotherKey: 'aValue' } }, { aKey: { anotherKey: 'aValue' } })).toEqual(true);
+      expect(
+        filterPayload(
+          { aKey: { anotherKey: 'aValue' } },
+          { aKey: { anotherKey: 'aValue' } },
+        ),
+      ).toEqual(true);
     });
     it('should go recursive and return false if a condition is not met', () => {
-      expect(filterPayload({ aKey: { anotherKey: 'aValue' } }, { aKey: { anotherKey: 'anotherValue' } })).toEqual(false);
+      expect(
+        filterPayload(
+          { aKey: { anotherKey: 'aValue' } },
+          { aKey: { anotherKey: 'anotherValue' } },
+        ),
+      ).toEqual(false);
     });
     it('should return true if at least one condition of the array is met', () => {
-      expect(filterPayload({ aKey: ['valueA', 'valueB', 'valueC'] }, { aKey: 'valueB' })).toEqual(true);
+      expect(
+        filterPayload(
+          { aKey: { $in: ['valueA', 'valueB', 'valueC'] } },
+          { aKey: 'valueB' },
+        ),
+      ).toEqual(true);
     });
     it('should return false if not a condition of the array is met', () => {
-      expect(filterPayload({ aKey: ['valueA', 'valueB', 'valueC'] }, { aKey: 'valueD' })).toEqual(false);
+      expect(
+        filterPayload(
+          { aKey: ['valueA', 'valueB', 'valueC'] },
+          { aKey: 'valueD' },
+        ),
+      ).toEqual(false);
+    });
+    it('should return true if an array is matched', () => {
+      expect(
+        filterPayload(
+          { aKey: ['valueA', 'valueB', 'valueC'] },
+          { aKey: ['valueA', 'valueB', 'valueC'] },
+        ),
+      ).toEqual(true);
     });
     it('should go recursive and return true if at least a condition of the array is met', () => {
       expect(
         filterPayload(
           {
-            aKey: [{ anotherKey: 'anotherValue' }, { yetAnotherKey: 'yetAnotherValue' }, 'valueC'],
+            aKey: { $in: [{ anotherKey: 'aValue' }, { anotherKey: 'bValue' }] },
           },
-          { aKey: { yetAnotherKey: 'yetAnotherValue' } },
+          { aKey: { anotherKey: 'aValue' } },
         ),
       ).toEqual(true);
     });
@@ -47,53 +87,95 @@ describe('WhispFilter', () => {
       expect(
         filterPayload(
           {
-            aKey: [{ anotherKey: 'anotherValue' }, { yetAnotherKey: 'yetAnotherValue' }, 'valueC'],
+            aKey: [
+              { anotherKey: 'anotherValue' },
+              { yetAnotherKey: 'yetAnotherValue' },
+              'valueC',
+            ],
           },
           { aKey: { yetAnotherKey: 'notTheExpectedValue' } },
         ),
       ).toEqual(false);
     });
     it('should return true if nested value matches', () => {
-      expect(filterPayload({ 'aKey.anotherKey': 'valueA' }, { aKey: { anotherKey: 'valueA' } })).toEqual(true);
+      expect(
+        filterPayload(
+          { 'aKey.anotherKey': 'valueA' },
+          { aKey: { anotherKey: 'valueA' } },
+        ),
+      ).toEqual(true);
     });
     it('should return true if several nested values match', () => {
       expect(
-        filterPayload({ 'key1.key2': 'valueA', 'key1.key3': 'valueB' }, { key1: { key2: 'valueA', key3: 'valueB' } }),
+        filterPayload(
+          { 'key1.key2': 'valueA', 'key1.key3': 'valueB' },
+          { key1: { key2: 'valueA', key3: 'valueB' } },
+        ),
       ).toEqual(true);
     });
-    it('should not return an object if it doesn\'t match fully', () => {
-      expect(filterPayload({ key1: { key2: 'ValueA' } }, { key1: { key2: 'ValueA', key3: 'ValueB' } })).toEqual(false);
+    it('should not return an object if it does not match fully', () => {
+      expect(
+        filterPayload(
+          { key1: { key2: 'ValueA' } },
+          { key1: { key2: 'ValueA', key3: 'ValueB' } },
+        ),
+      ).toEqual(false);
     });
-  });
 
-  describe('payloadMatchesNestedValue', () => {
-    it('should match', () => {
+    it('should return true if a mongo eq query succeeds', () => {
       expect(
-        payloadMatchesNestedValue(['att1', 'att2', 'att3'], 'ValueA', {
-          att1: { att2: { att3: 'ValueA' } },
-        }),
+        filterPayload(
+          { 'key1.key2': { $eq: 'ValueA' } },
+          { key1: { key2: 'ValueA' } },
+        ),
       ).toEqual(true);
     });
-    it('should not match if value differs', () => {
+    it('should return true if a mongo gte query succeeds', () => {
+      expect(filterPayload({ key1: { $gte: 5 } }, { key1: 6 })).toEqual(true);
+    });
+    it('should return true if a complex mongo query succeeds', () => {
       expect(
-        payloadMatchesNestedValue(['att1', 'att2', 'att3'], 'ValueA', {
-          att1: { att2: { att3: 'ValueB' } },
-        }),
+        filterPayload(
+          {
+            key1: { $eq: 'valueA' },
+            key2: { $gte: 5 },
+            key3: { $in: ['value1', 'value2'] },
+            'key4.key5': { $lt: 5 },
+          },
+          {
+            key1: 'valueA',
+            key2: 7,
+            key3: 'value2',
+            key4: { key5: 4 },
+          },
+        ),
+      ).toEqual(true);
+    });
+    it('should return false if a mongo query fails', () => {
+      expect(
+        filterPayload(
+          { 'key1.key2': { $eq: 'ValueA' } },
+          { key1: { key2: 'ValueB' } },
+        ),
       ).toEqual(false);
     });
-    it('should not match if property is not there', () => {
+    it('should handle a stringified filter', () => {
+      const filter = JSON.stringify({
+        key1: { $eq: 'valueA' },
+        key2: { $gte: 5 },
+        key3: { $in: ['value1', 'value2'] },
+        'key4.key5': { $lt: 5 },
+      });
       expect(
-        payloadMatchesNestedValue(['att1', 'att2', 'att3'], 'ValueA', {
-          att1: { att2: 'ValueA' },
-        }),
-      ).toEqual(false);
-    });
-    it('should match if there are other properties', () => {
-      expect(
-        payloadMatchesNestedValue(['att1', 'att2', 'att3'], 'ValueA', {
-          att1: { att2: { att3: 'ValueA' } },
-          att4: 'ValueB',
-        }),
+        filterPayload(
+          filter,
+          {
+            key1: 'valueA',
+            key2: 7,
+            key3: 'value2',
+            key4: { key5: 4 },
+          },
+        ),
       ).toEqual(true);
     });
   });


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


**What is the current behavior?** (You can also link to an open issue here)
View the issue https://github.com/Sanofi-IADC/whispr/issues/425
Basically the current filters on webhooks and subscriptions are not using mongoDB query language.


**What is the new behavior (if this is a feature change)?**
Webhooks and subscriptions are now aligned with the other whisp filters and use the mongoDB query language.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Only noticeable change is with the following filter:
```
filter: {
  keyA: ['a','b','c']
}
```
Previously the webhook filters handled an array in the filter as possible options and returned true for a whisp like this:
```
whisp: {
  keyA: 'b'
}
```
After this change the filter will return false on the whisp above but true on this:
```
whisp: {
  keyA: ['a','b','c']
}
```
To receive the previous behaviour use the mongoDB query parameter `$in` :
```
filter: {
  keyA: { 
    $in:['a','b','c']
  }
}
```


**Other information**:
In my test the current webhook filter implementation takes around 0.015 milliseconds per filtering. The new implementation takes around 0.12 milliseconds per filtering.