### PR TITLE
fix: docker image repository for instana layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ COPY package*.json ./
 RUN npm ci --quiet --only=production
 
 # Add the Instana APM layer
-COPY --from=instana/aws-fargate-nodejs /instana /instana
+COPY --from=icr.io/instana/aws-fargate-nodejs:latest /instana /instana
 RUN /instana/setup.sh
 ENV NODE_OPTIONS="--require /instana/node_modules/@instana/aws-fargate"
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix


* **What is the current behavior?** (You can also link to an open issue here)

build failing with error message: `invalid from flag value instana/aws-fargate-nodejs: pull access denied for instana/aws-fargate-nodejs`

* **What is the new behavior (if this is a feature change)?**

build successful

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

* **Other information**:

Fargate layer image provided by Instana is no longer hosted on [DockerHub](https://hub.docker.com/) but on [icr.io](https://www.ibm.com/cloud/container-registry). 

As a consequence, the Dockerfile used in this project need to be updated.